### PR TITLE
Fix NVMe drive detection and Temp Regex

### DIFF
--- a/hush/hardware/smart.py
+++ b/hush/hardware/smart.py
@@ -24,13 +24,14 @@ class Smart(Device):
 
     async def get_drive_temp(self, drive_path):
         try:
-            result = await self.ssh.shell(f'smartctl -x {drive_path} | grep -E "Temp|Cel|Cur|temp|cel|cur"')
-            temp = re.search(r"(Current\s+)?Temperature:\s*(\d+)", result.stdout)
-            if temp is not None and temp.lastindex == 1:
-                return float(temp.group(1))
-            else:
-                logger.info(f"{self.hostname} failed to get drive temperature {drive_path}:")
-                logger.info(f"result = {result}")
+            result = await self.ssh.shell(f'smartctl -x {drive_path} | grep -E "Temperature|temperature"')
+            for line in result.stdout_lines:
+                temp = re.search(r"^(?:Current(?:\sDrive)?\s)?Temperature:\s*(\d+)", line)
+                if temp is not None and temp.lastindex == 1:
+                    return float(temp.group(1))
+            logger.info(f"{self.hostname} failed to get drive temperature {drive_path}:")
+            logger.info(f"result = {result}")
+            return None
         except Exception as e:
             logger.info(f"{self.hostname} failed to get drive temperature {drive_path}:")
             logger.info(f"result = {result}")

--- a/hush/hardware/smart.py
+++ b/hush/hardware/smart.py
@@ -15,7 +15,7 @@ class Smart(Device):
         drive_paths = list()
         try:
             result = await self.ssh.shell("fdisk -l")
-            drive_paths = re.findall(r"Disk (\/dev\/sd[a-z]+|\/dev\/nvm[0-9]+n[0-9]+)", result.stdout)
+            drive_paths = re.findall(r"Disk (\/dev\/sd[a-z]+|\/dev\/nvme[0-9]+n[0-9]+)", result.stdout)
         except Exception as e:
             logger.info(f"{self} failed to get drive list:")
             logger.info(f"result = {result}")
@@ -25,7 +25,7 @@ class Smart(Device):
     async def get_drive_temp(self, drive_path):
         try:
             result = await self.ssh.shell(f'smartctl -x {drive_path} | grep -E "Temp|Cel|Cur|temp|cel|cur"')
-            temp = re.search(r"Current(?:\sDrive)?\sTemperature:\s*(\d+)", result.stdout)
+            temp = re.search(r"(Current\s+)?Temperature:\s*(\d+)", result.stdout)
             if temp is not None and temp.lastindex == 1:
                 return float(temp.group(1))
             else:


### PR DESCRIPTION
There was a typo in the NVMe drive name that ignored NVMe drivers  from the fdisk -l response.

Also, the Regex for finding the driver's temperature was not compatible with the latest versions of the output.

In smartctl 7.3 2022-02-28 r5338, the output for NVMe drivers reads only "Temperature:                        36 Celsius" whereas for other disks it reads as "Current Temperature:                    42 Celsius".

The Regex now captures both entries.