### PR TITLE
fix(idrac): set fan mode to manual on each iteration

### DIFF
--- a/hush/hardware/idrac.py
+++ b/hush/hardware/idrac.py
@@ -140,8 +140,7 @@ class Ipmi(Device):
 
     async def set_speed(self, speed: int) -> None:
         self._speed = speed
-        if self._fan_mode != self.FanMode.MANUAL:
-            await self.set_fan_mode(self.FanMode.MANUAL)
+        await self.set_fan_mode(self.FanMode.MANUAL)
         pwm = hex(int(self._speed))
         if self._speed != pwm:
             self._speed = pwm


### PR DESCRIPTION
It seems that currently iDRAC doesn't favor the fan mode set by the user at all times. At some point, the mode may get overridden back to automatic (`FanMode.IDRAC`), without any action done by the user that could make that happen.

It also seems like there is no API for _reading_ the currently selected fan mode from iDRAC, which makes it tricky to understand the current fan mode in the system.

This PR removes assumption that the `_fan_mode` is the source of truth for the current fan mode, and instead applies manual fan mode (`FanMode.MANUAL`) on each `set_speed` call to avoid the issue where iDRAC has reset the fan mode back to automatic (`FanMode.IDRAC`) for one reason or another, and we can't learn about it programmatically.
